### PR TITLE
Do not overwrite if files exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var nyg = function(prompts,globs) {
 nyg.prototype = Object.create(EventEmitter.prototype);
 /* Public Functions */
 nyg.prototype.run = function() {
-  this.cwd = process.cwd();
+  this.cwd = this.cwd || process.cwd();
   this.config.chdir(this.cwd);
   this.config.set('nyg-version',this.version);
   this.config.set('generator-version',this.generator);

--- a/lib/template.js
+++ b/lib/template.js
@@ -23,19 +23,33 @@ var template = module.exports = function(inputs,output,cb) {
 };
 
 template.template = function(input,output,cb) {
-  fs.readFile(input,'utf8',function(err,str) {
-    if (err) throw err;
-    fs.writeFile(parsePath(output),template.parse(str),function(err) {
-      if (err) throw err;
+  // check whether the file exists. If it does not then template
+  fs.exists(output, function(exists) {
+    if(!exists) {
+      fs.readFile(input,'utf8',function(err,str) {
+        if (err) throw err;
+        fs.writeFile(parsePath(output),template.parse(str),function(err) {
+          if (err) throw err;
+          cb();
+        });
+      });
+    } else {
       cb();
-    });
-  })
+    }
+  });
 };
 
 template.copy = function(input,output,cb) {
-  var write = fs.createWriteStream(parsePath(output));
-  write.on('finish',cb);
-  fs.createReadStream(input).pipe(write);
+  // check whether the file exists. If it does not then copy
+  fs.exists(output, function(exists) {
+    if(!exists) {
+      var write = fs.createWriteStream(parsePath(output));
+      write.on('finish',cb);
+      fs.createReadStream(input).pipe(write);
+    } else {
+      cb();
+    }
+  });
 };
 
 template.parse = function(string) {


### PR DESCRIPTION
There are cases where you may want to for instance update an existing repo with a new generator. In this case you don't want to overwrite ALL the files but just the files that do not exist. This is how `module-generator` works and it's fantastic.

This pull request adds in checks to see whether files exist. If they exist they will not be overwritten. It would be nice if you could pass in an option at some point to force overwrite.
