### PR TITLE
options + save config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,14 @@ Options:
 
 ## API
 
-### `nyg(prompts,globs)`
+### `nyg(prompts,globs,[options])`
 
 The main entry point to nyg. Returns an nyg instance.
 
 ```prompts``` a single questions or an array of questions to ask the user, using [inquirer](https://www.npmjs.com/package/inquirer) syntax.  
 ```globs``` a single glob or an array of globs specifying which files to copy and to where.  
+```options``` an optional object which can be passed in. These options will be merged in with data gathered via `prompts`. This can be useful if for instance you want to template in a Date or some other hardcoded value. You can also pass in:
+- `saveConfig` - which if set to `false` will ensure that the `nyg-cfg.json` will not be written.
 
 ### `nyg.run()`
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var nyg = function(prompts,globs) {
 nyg.prototype = Object.create(EventEmitter.prototype);
 /* Public Functions */
 nyg.prototype.run = function() {
-  this.cwd = process.cwd();
+  this.cwd = this.cwd || process.cwd();
   this.config.chdir(this.cwd);
   this.config.set('nyg-version',this.version);
   this.config.set('generator-version',this.generator);


### PR DESCRIPTION
This pull request allows for passing an `options` object along with `globs` and `prompts`.

This `options` objects values will be merged into `store`. This means you could for instance hardcode a date or commit number or something that would not be prompted for.

I also added the ability to pass in a value `saveConfig` which would allow for the user to be able to choose whether a config file will be saved. The neat thing is that that this value is checked from `this.config.get('saveConfig')` which means that you could even get the users prompt for this.
