### PR TITLE
Added a new option `npmInstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ The main entry point to nyg. Returns an nyg instance.
 ```prompts``` a single questions or an array of questions to ask the user, using [inquirer](https://www.npmjs.com/package/inquirer) syntax.  
 ```globs``` a single glob or an array of globs specifying which files to copy and to where.  
 ```options``` an optional object which can be passed in. These options will be merged in with data gathered via `prompts`. This can be useful if for instance you want to template in a Date or some other hardcoded value. You can also pass in:
-- `saveConfig` - which if set to `false` will ensure that the `nyg-cfg.json` will not be written.
+- `saveConfig` - which if set to `false` will ensure that the `nyg-cfg.json` 
+will not be written.
+- `npmInstall` - if set to false then `npm install` will not be called.
 
 These parameters can also be passed in as a single object to nyg. `prompts` and `globs` are reserved keywords in this object but everything else will be treated as the options parameter.
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,13 @@ nyg.prototype.run = function() {
     this.config.set(key, this._options[key]);
   }.bind(this));
 
-  this._tasks = [this._startPrompt.bind(this),this._runPrompt.bind(this),this._startTemplate.bind(this),this._runTemplate.bind(this),this._startInstall.bind(this),this._runInstall.bind(this)];
+  this._tasks = [this._startPrompt.bind(this),this._runPrompt.bind(this),this._startTemplate.bind(this),this._runTemplate.bind(this)];
+
+  // if option npmInstall is set then run npm events
+  if(this.config.get('npmInstall') === undefined || this.config.get('npmInstall')) {
+    this._tasks.push(this._startInstall.bind(this),this._runInstall.bind(this));
+  }
+  
   this._running = true;
   process.nextTick(this._next.bind(this));
   return this;


### PR DESCRIPTION
Implemented a new option `npmInstall` that when passed will prevent `npm install` being called on templated folder.
